### PR TITLE
Show actual data on search results page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_site
+.sass-cache

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ source 'https://rubygems.org' do
   gem 'rest-client'
   gem 'sinatra-jekyll'
   gem 'pry'
+  gem 'fuzzy_match'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
     domain_name (0.5.20160128)
       unf (>= 0.0.5, < 1.0.0)
     ffi (1.9.10)
+    fuzzy_match (2.1.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     jekyll (3.1.2)
@@ -96,6 +97,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  fuzzy_match!
   jekyll
   jekyll-compass
   jekyll-everypolitician

--- a/app.rb
+++ b/app.rb
@@ -7,6 +7,8 @@ configure do
   set :jekyll_site_path, 'shineyoureye'
   set :pu_lookup_api_url, 'https://pu-lookup.herokuapp.com'
   jekyll_site.config['url'] ||= 'http://staging.shineyoureye.org'
+  # Run generators for Jekyll
+  jekyll_site.generate
 end
 
 helpers do
@@ -26,6 +28,12 @@ get '/' do
   if params[:q]
     @result = pu_lookup(params[:q])
     @area = @result[:area]
+    @state = @result[:states].first
+    @governor = jekyll_site.collections['executive_governors'].docs.find_all do |d|
+      d['area'] == @state[:name]
+    end.reject do |d|
+      d['end_date'] && Date.parse(d['end_date']) < Date.today
+    end.first
   end
   render_into_jekyll_layout erb(:index), 'disable_breadcrumbs' => true
 end

--- a/app.rb
+++ b/app.rb
@@ -34,6 +34,14 @@ get '/' do
     end.reject do |d|
       d['end_date'] && Date.parse(d['end_date']) < Date.today
     end.first
+    assembly_fuzzer = FuzzyMatch.new(jekyll_site.collections['assembly_areas'].docs, read: 'name')
+    @federal_constituencies = @result[:federal_constituencies].map do |fc|
+      assembly_fuzzer.find(fc[:name])
+    end.compact
+    senate_fuzzer = FuzzyMatch.new(jekyll_site.collections['senate_areas'].docs, read: 'name')
+    @senatorial_districts = @result[:senatorial_districts].map do |sd|
+      senate_fuzzer.find(sd[:name])
+    end.compact
   end
   render_into_jekyll_layout erb(:index), 'disable_breadcrumbs' => true
 end

--- a/views/index.erb
+++ b/views/index.erb
@@ -33,25 +33,42 @@
   <h3>Overlapping Federal Constituencies</h3>
 
   <ul>
+    <% @federal_constituencies.each do |federal_constituency| %>
 
-    <li><a href="/place/aba-north-aba-south/">Aba North/Aba South</a>,
+      <li><a href="<%= jekyll_site.config['url'] + federal_constituency.url %>"><%= federal_constituency['name'] %></a>,
 
-      no current representative
+        <% if federal_constituency['memberships'].any? %>
+          <% federal_constituency['memberships'].each do |membership| %>
+            current representative <a href="<%= jekyll_site.config['url'] + membership['person'].url %>"><%= membership['person']['name'] %></a>
+          <% end %>
+        <% else %>
+          no current representative
+        <% end %>
 
-    </li>
+      </li>
+
+    <% end %>
 
   </ul>
 
   <h3>Overlapping Senatorial Districts</h3>
 
   <ul>
+    <% @senatorial_districts.each do |senatorial_district| %>
 
-    <li><a href="/place/abia-south/">ABIA SOUTH</a>,
+      <li><a href="<%= jekyll_site.config['url'] + senatorial_district.url %>"><%= senatorial_district['name'] %></a>,
 
-      current senator <a href="/person/abaribe-enyinnaya-harcourt/">ABARIBE ENYINNAYA HARCOURT</a>
+        <% if senatorial_district['memberships'].any? %>
+          <% senatorial_district['memberships'].each do |membership| %>
+            current senator <a href="<%= jekyll_site.config['url'] + membership['person'].url %>"><%= membership['person']['name'] %></a>
+          <% end %>
+        <% else %>
+          no current senator
+        <% end %>
 
-    </li>
+      </li>
 
+    <% end %>
   </ul>
 
 <% elsif params[:q] %>

--- a/views/index.erb
+++ b/views/index.erb
@@ -17,14 +17,17 @@
 
     <p>Best match is the <%= @area[:type_name] %> "<%= @area[:name] %>" with poll unit number '<%= @area[:codes][:poll_unit] %>'</p>
 
-
-  <h3>State</h3>
-  <p>
-  <a href="/place/abia/">Abia</a>,
-
-  current governor <a href="/person/okezie-ikpeazu/">Okezie Ikpeazu </a>
-
-  </p>
+    <% if @state %>
+      <h3>State</h3>
+      <p>
+      <%= @state[:name] %>,
+      <% if @governor %>
+        current governor <a href="<%= jekyll_site.config['url'] + @governor.url %>"><%= @governor['name'] %></a>
+      <% else %>
+        no current governor
+      <% end %>
+      </p>
+    <% end %>
 
 
   <h3>Overlapping Federal Constituencies</h3>


### PR DESCRIPTION
The state, federal constituencies and senatorial districts shown on the results page are now using real data and linking to the jekyll site.

![screen shot 2016-06-07 at 16 22 07](https://cloud.githubusercontent.com/assets/22996/15861158/006cbbce-2ccc-11e6-8026-898af8ace2f6.png)
